### PR TITLE
Remove console.log

### DIFF
--- a/lib/core/ProxyHandler.js
+++ b/lib/core/ProxyHandler.js
@@ -80,7 +80,6 @@
 					auth : sAuthData,
 					headers : this._prepareHeadersToBeForwarded(oConfig.host, oConfig.headers, req.headers)
 			}, function (oResponse) {
-					console.log('response from:', oConfig.host,iProxyPort, req.url)
 					this._pipeResponseBackToOriginalRes(oResponse,res);
 			}.bind(this));
 


### PR DESCRIPTION
This seems to be the only `console.log` in the project, and looks like it was left there by mistake?
