### PR TITLE
add rewriteHost config param to support various proxy setups

### DIFF
--- a/lib/core/ProxyHandler.js
+++ b/lib/core/ProxyHandler.js
@@ -9,7 +9,7 @@
 				'http' : require('http'),
 				'https' : require('https')
 		};
-	};
+	}
 
 	ProxyHandler.prototype.proxyTunneling = function(oConfig,req,res){
 			var oProxyTunnelConfig = oConfig.proxyTunnel;
@@ -35,7 +35,7 @@
 							method : req.method,
 							path : req.url,
 							auth : sAuthData,
-							headers : this._prepareHeadersToBeForwarded(oConfig.host, oConfig.headers, req.headers)
+							headers : this._prepareHeadersToBeForwarded(oConfig, req.headers)
 					}, function (oResponse) {
 							this._pipeResponseBackToOriginalRes(oResponse,res);
 					}.bind(this));
@@ -58,7 +58,7 @@
 					port: iProxyPort,
 					method: req.method,
 					path: sPathProtocol + '://' + oConfig.host + ':' + iPathPort + req.url,
-					headers : this._prepareHeadersToBeForwarded(oConfig.host, oConfig.headers, req.headers)
+					headers : this._prepareHeadersToBeForwarded(oConfig, req.headers)
 			}, function (oResponse) {
 					this._pipeResponseBackToOriginalRes(oResponse,res);
 			}.bind(this));
@@ -78,7 +78,7 @@
 					method: req.method,
 					path: req.url,
 					auth : sAuthData,
-					headers : this._prepareHeadersToBeForwarded(oConfig.host, oConfig.headers, req.headers)
+					headers : this._prepareHeadersToBeForwarded(oConfig, req.headers)
 			}, function (oResponse) {
 					this._pipeResponseBackToOriginalRes(oResponse,res);
 			}.bind(this));
@@ -86,18 +86,24 @@
 			this._pipeOriginalReqBodyToProxyRequest(req,oProxyRequest);
 	};
 
-	ProxyHandler.prototype._prepareHeadersToBeForwarded = function(sHost, oConfigHeaders, oReqHeaders){
+	ProxyHandler.prototype._prepareHeadersToBeForwarded = function(oConfig, oReqHeaders){
+
+			var oConfigHeaders = oConfig.headers;
+
 			if (!oConfigHeaders){
 				oConfigHeaders = {};
-			};
+			}
+
+			var rewriteHost = oConfig.rewriteHost === null || oConfig.rewriteHost === true;
 
 			Object.keys(oReqHeaders).forEach(function(sProperty){
-					if (sProperty.match(/host/i)){ //Fix HOST
-						oConfigHeaders[sProperty] = sHost;
-						return;
-					}
-					oConfigHeaders[sProperty] = oReqHeaders[sProperty];
+				if (sProperty.match(/host/i) && rewriteHost){ //Fix HOST
+					oConfigHeaders[sProperty] = oConfig.host;
+					return;
+				}
+				oConfigHeaders[sProperty] = oReqHeaders[sProperty];
 			});
+
 			return oConfigHeaders;
 	};
 

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,7 @@ grunt.initConfig({
                     host: 'api_server_domain.com', //REQUIRED! Should not contain 'http://' or 'https://'
                     port: 8080, //Optional, defaults to 80 if http or 443 if https
                     https: false,//Optional, defaults to false
+                    rewriteHost: true,//Optional, defaults to true
                     auth: 'username:password', //Optional, adds the Authorization header
                     headers: {//Optional.
                         'header':'value'
@@ -74,6 +75,7 @@ grunt.initConfig({
                     host: 'api_server_domain.com', //REQUIRED! Should not contain 'http://' or 'https://'
                     port: 8080, //Optional, defaults to 80 if http or 443 if https
                     https: false,//Optional, defaults to false
+                    rewriteHost: true,//Optional, defaults to true
                     /*auth is not supported*/
                     headers: {//Optional.
                         'header':'value'
@@ -110,6 +112,7 @@ grunt.initConfig({
                     host: 'api_server_domain.com', //REQUIRED! Should not contain 'http://' or 'https://'
                     port: 8080, //Optional, defaults to 80 if http or 443 if https
                     https: false,//Optional, defaults to false
+                    rewriteHost: true,//Optional, defaults to true
                     auth: 'username:password', //Optional, adds the Authorization header
                     headers: {//Optional.
                         'header':'value'
@@ -157,6 +160,12 @@ The available configuration options from a given proxy based on the node [http](
 >Default: false
 
 >If the proxy should target a https end point on the destination server
+
+#### options.rewriteHost
+>Type: `Boolean`
+>Default: true
+
+>If the proxy should rewrite the host header to the target host. If your use case depends on proxying to localhost servers with port, try setting rewriteHost to false.
 
 #### options.port
 >Type: `Number`


### PR DESCRIPTION
Currently the host header always gets overwritten when proxying a request. But if the target host needs the original host information (with the port) this behavior is wrong. I introduced an optional configuration parameter to allow for _not_ rewriting the host information.

Simple example:
connect server is running on localhost:9101, request gets proxied to localhost:8080. the target host should redirect back to localhost:9101. With `rewriteHost: false` set I can achieve that.
